### PR TITLE
Refactor the code to use Instruction enum instead of String

### DIFF
--- a/src/main/java/com/hhaouari/roverscan/entities/Rover.java
+++ b/src/main/java/com/hhaouari/roverscan/entities/Rover.java
@@ -1,8 +1,10 @@
 package com.hhaouari.roverscan.entities;
 
 import com.hhaouari.roverscan.entities.enums.Direction;
+import com.hhaouari.roverscan.entities.enums.Instruction;
 import lombok.Data;
 
+import java.util.Arrays;
 import java.util.Objects;
 
 @Data
@@ -10,23 +12,50 @@ public class Rover {
     private long x;
     private long y;
     private Direction direction;
-    private String instructions;
+    private Instruction[] instructions;
 
     public Rover() {
     }
 
-    public Rover(long x, long y, Direction direction, String instructions) {
-        this.x = x;
-        this.y = y;
+    public Rover(long x, long y, Direction direction, Instruction[] instructions) {
+        setRoverPosition(x, y);
         this.direction = direction;
         this.instructions = instructions;
     }
 
-    public Rover(long x, long y, String direction, String instructions) {
+    private void setRoverPosition(long x, long y) {
         this.x = x;
         this.y = y;
-        this.direction = Direction.valueOf(direction);
+    }
+
+    public Rover(long x, long y, String direction, String instructions) {
+        setRoverPosition(x, y);
+        this.setDirection(direction);
+        this.setInstructions(instructions);
+    }
+
+    public Rover(long x, long y, Direction direction, String instructions) {
+        setRoverPosition(x, y);
+        this.setDirection(direction);
+        this.setInstructions(instructions);
+    }
+
+    public void setInstructions(String instructions) {
+        this.instructions = Arrays.stream(instructions.split(""))
+                .map(Instruction::valueOf)
+                .toArray(Instruction[]::new);
+    }
+
+    public void setInstructions(Instruction[] instructions) {
         this.instructions = instructions;
+    }
+
+    public void setDirection(String direction) {
+        this.direction = Direction.valueOf(direction);
+    }
+
+    public void setDirection(Direction direction) {
+        this.direction = direction;
     }
 
 
@@ -43,7 +72,7 @@ public class Rover {
 
     @Override
     public int hashCode() {
-        return Objects.hash(getX(), getY(), getDirection(), getInstructions());
+        return Objects.hash(getX(), getY(), getDirection(), Arrays.hashCode(getInstructions()));
     }
 
     @Override

--- a/src/main/java/com/hhaouari/roverscan/entities/enums/Instruction.java
+++ b/src/main/java/com/hhaouari/roverscan/entities/enums/Instruction.java
@@ -1,0 +1,4 @@
+package com.hhaouari.roverscan.entities.enums;
+public enum Instruction {
+    M, L, R
+}

--- a/src/main/java/com/hhaouari/roverscan/services/DirectionHelper.java
+++ b/src/main/java/com/hhaouari/roverscan/services/DirectionHelper.java
@@ -1,7 +1,10 @@
 package com.hhaouari.roverscan.services;
 
 import com.hhaouari.roverscan.entities.enums.Direction;
+import com.hhaouari.roverscan.entities.enums.Instruction;
 
 public interface DirectionHelper {
+    Direction getNewDirection(Direction currentDirection, Instruction newDirectionInstruction);
+
     Direction getNewDirection(Direction currentDirection, char newDirectionInstruction);
 }

--- a/src/main/java/com/hhaouari/roverscan/services/impl/DirectionHelperImpl.java
+++ b/src/main/java/com/hhaouari/roverscan/services/impl/DirectionHelperImpl.java
@@ -1,23 +1,29 @@
 package com.hhaouari.roverscan.services.impl;
 
 import com.hhaouari.roverscan.entities.enums.Direction;
+import com.hhaouari.roverscan.entities.enums.Instruction;
 import com.hhaouari.roverscan.exceptions.DirectionInvalidInstructionException;
 import com.hhaouari.roverscan.services.DirectionHelper;
 
 public class DirectionHelperImpl implements DirectionHelper {
 
     @Override
-    public Direction getNewDirection(Direction currentDirection, char newDirectionInstruction) {
+    public Direction getNewDirection(Direction currentDirection, Instruction newDirectionInstruction) {
         switch (newDirectionInstruction) {
-            case 'L' -> {
+            case L -> {
                 return getDirectionAfterLeftTurn(currentDirection);
             }
-            case 'R' -> {
+            case R -> {
                 return getDirectionAfterRightTurn(currentDirection);
             }
             default -> throw new DirectionInvalidInstructionException(
                     "Invalid direction instruction: " + newDirectionInstruction);
         }
+    }
+
+    @Override
+    public Direction getNewDirection(Direction currentDirection, char newDirectionInstruction) {
+        return this.getNewDirection(currentDirection, Instruction.valueOf(String.valueOf(newDirectionInstruction)));
     }
 
     private static Direction getDirectionAfterRightTurn(Direction currentDirection) {

--- a/src/main/java/com/hhaouari/roverscan/services/impl/RoverControlServiceImpl.java
+++ b/src/main/java/com/hhaouari/roverscan/services/impl/RoverControlServiceImpl.java
@@ -2,6 +2,7 @@ package com.hhaouari.roverscan.services.impl;
 
 import com.hhaouari.roverscan.entities.Plateau;
 import com.hhaouari.roverscan.entities.Rover;
+import com.hhaouari.roverscan.entities.enums.Instruction;
 import com.hhaouari.roverscan.services.DirectionHelper;
 import com.hhaouari.roverscan.services.PositionHelper;
 import com.hhaouari.roverscan.services.RoverControlService;
@@ -21,19 +22,17 @@ public class RoverControlServiceImpl implements RoverControlService {
      */
     @Override
     public boolean move(Rover rover, Plateau plateau) {
-        String roverInstructions = rover.getInstructions();
+        Instruction[] roverInstructions = rover.getInstructions();
         if (roverInstructions == null) {
             return false;
         }
-        for (int i = 0; i < roverInstructions.length(); i++) {
-            char instruction = roverInstructions.charAt(i);
-            if (instruction == 'M') {
+        for (Instruction instruction: roverInstructions) {
+            if (instruction.equals(Instruction.M)) {
                 moveForward(rover, plateau);
             } else {
                 rover.setDirection(directionHelper.getNewDirection(rover.getDirection(), instruction));
             }
         }
-        rover.setInstructions(null);
         return true;
     }
 
@@ -45,7 +44,7 @@ public class RoverControlServiceImpl implements RoverControlService {
      */
     @Override
     public boolean turnLeft(Rover rover) {
-        rover.setDirection(directionHelper.getNewDirection(rover.getDirection(), 'L'));
+        rover.setDirection(directionHelper.getNewDirection(rover.getDirection(), Instruction.L));
         return true;
     }
 
@@ -57,7 +56,7 @@ public class RoverControlServiceImpl implements RoverControlService {
      */
     @Override
     public boolean turnRight(Rover rover) {
-        rover.setDirection(directionHelper.getNewDirection(rover.getDirection(), 'R'));
+        rover.setDirection(directionHelper.getNewDirection(rover.getDirection(), Instruction.R));
         return true;
     }
 

--- a/src/main/java/com/hhaouari/roverscan/utils/CoordinateStringReader.java
+++ b/src/main/java/com/hhaouari/roverscan/utils/CoordinateStringReader.java
@@ -3,6 +3,7 @@ package com.hhaouari.roverscan.utils;
 import com.hhaouari.roverscan.entities.Plateau;
 import com.hhaouari.roverscan.entities.Rover;
 import com.hhaouari.roverscan.entities.enums.Direction;
+import com.hhaouari.roverscan.entities.enums.Instruction;
 
 public class CoordinateStringReader {
 
@@ -24,7 +25,11 @@ public class CoordinateStringReader {
         rover.setX(Long.parseLong(coordinates[0]));
         rover.setY(Long.parseLong(coordinates[1]));
         rover.setDirection(Direction.valueOf(coordinates[2]));
-        rover.setInstructions(instructions);
+        Instruction[] instructionsEnum = new Instruction[instructions.length()];
+        for (int i = 0; i < instructions.length(); i++) {
+            instructionsEnum[i] = Instruction.valueOf(String.valueOf(instructions.charAt(i)));
+        }
+        rover.setInstructions(instructionsEnum);
         return rover;
     }
 

--- a/src/test/java/com/hhaouari/roverscan/entities/MissionTest.java
+++ b/src/test/java/com/hhaouari/roverscan/entities/MissionTest.java
@@ -1,22 +1,39 @@
 package com.hhaouari.roverscan.entities;
 
+import com.hhaouari.roverscan.entities.enums.Direction;
+import com.hhaouari.roverscan.entities.enums.Instruction;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Array;
+import java.util.Arrays;
 
 import static org.junit.jupiter.api.Assertions.*;
 class MissionTest {
+
+    private static final Instruction[] instructions1 = new Instruction[]{
+            Instruction.L,
+            Instruction.M,
+            Instruction.L,
+            Instruction.M,
+            Instruction.L,
+            Instruction.M,
+            Instruction.L,
+            Instruction.M,
+            Instruction.M};
 
     @Test
     void testEquals() {
         Mission mission1 = new Mission();
         mission1.setPlateau(new Plateau(5, 5));
-        mission1.addRover(new Rover(1, 2, "N", "LMLMLMLMM"));
-        mission1.addRover(new Rover(3, 3, "E", "MMRMMRMRRM"));
-        mission1.addRover(new Rover(5, 5, "S", "MMRMMRMRRM"));
+        mission1.addRover(new Rover(1, 2, Direction.N, instructions1));
+        mission1.addRover(new Rover(3, 3, Direction.E, instructions1));
+        mission1.addRover(new Rover(5, 5, Direction.S, instructions1));
         Mission mission2 = new Mission();
         mission2.setPlateau(new Plateau(5, 5));
-        mission2.addRover(new Rover(1, 2, "N", "LMLMLMLMM"));
-        mission2.addRover(new Rover(3, 3, "E", "MMRMMRMRRM"));
-        mission2.addRover(new Rover(5, 5, "S", "MMRMMRMRRM"));
+        mission2.addRover(new Rover(1, 2, Direction.N, instructions1));
+        mission2.addRover(new Rover(3, 3, Direction.E, instructions1));
+        mission2.addRover(new Rover(5, 5, Direction.S, instructions1));
         assertEquals(mission1, mission2);
       }
 
@@ -24,14 +41,15 @@ class MissionTest {
     void testEqualsNoEqual() {
         Mission mission1 = new Mission();
         mission1.setPlateau(new Plateau(5, 5));
-        mission1.addRover(new Rover(1, 2, "N", "LMLMLMLMM"));
-        mission1.addRover(new Rover(3, 3, "E", "MMRMMRMRRM"));
-        mission1.addRover(new Rover(5, 5, "S", "MMRMMRMRRM"));
+        mission1.addRover(new Rover(1, 2, Direction.N, instructions1));
+        mission1.addRover(new Rover(3, 3, Direction.E, instructions1));
+        mission1.addRover(new Rover(5, 5, Direction.S, instructions1));
         Mission mission2 = new Mission();
         mission2.setPlateau(new Plateau(5, 5));
-        mission2.addRover(new Rover(1, 2, "N", "LMLMLMLMM"));
-        mission2.addRover(new Rover(3, 3, "E", "MMRMMRMRRM"));
-        mission2.addRover(new Rover(5, 3, "S", "MMRMMRMRRM"));
+        mission2.addRover(new Rover(1, 2, Direction.N, instructions1));
+        mission2.addRover(new Rover(3, 3, Direction.E, instructions1));
+        mission2.addRover(new Rover(5, 5, Direction.S, instructions1));
+        mission2.addRover(new Rover(5, 5, Direction.S, instructions1));
         assertNotEquals(mission1, mission2);
     }
 
@@ -41,14 +59,14 @@ class MissionTest {
     void testHashCode() {
         Mission mission1 = new Mission();
         mission1.setPlateau(new Plateau(5, 5));
-        mission1.addRover(new Rover(1, 2, "N", "LMLMLMLMM"));
-        mission1.addRover(new Rover(3, 3, "E", "MMRMMRMRRM"));
-        mission1.addRover(new Rover(5, 5, "S", "MMRMMRMRRM"));
+        mission1.addRover(new Rover(1, 2, Direction.N, instructions1));
+        mission1.addRover(new Rover(3, 3, Direction.E, instructions1));
+        mission1.addRover(new Rover(5, 5, Direction.S, instructions1));
         Mission mission2 = new Mission();
         mission2.setPlateau(new Plateau(5, 5));
-        mission2.addRover(new Rover(1, 2, "N", "LMLMLMLMM"));
-        mission2.addRover(new Rover(3, 3, "E", "MMRMMRMRRM"));
-        mission2.addRover(new Rover(5, 5, "S", "MMRMMRMRRM"));
+        mission2.addRover(new Rover(1, 2, Direction.N, instructions1));
+        mission2.addRover(new Rover(3, 3, Direction.E, instructions1));
+        mission2.addRover(new Rover(5, 5, Direction.S, instructions1));
         assertEquals(mission1.hashCode(), mission2.hashCode());
 
       }
@@ -57,9 +75,9 @@ class MissionTest {
     void testToString() {
         Mission mission1 = new Mission();
         mission1.setPlateau(new Plateau(5, 5));
-        mission1.addRover(new Rover(1, 2, "N", "LMLMLMLMM"));
-        mission1.addRover(new Rover(3, 3, "E", "MMRMMRMRRM"));
-        mission1.addRover(new Rover(5, 5, "S", "MMRMMRMRRM"));
+        mission1.addRover(new Rover(1, 2, Direction.N, instructions1));
+        mission1.addRover(new Rover(3, 3, Direction.E, instructions1));
+        mission1.addRover(new Rover(5, 5, Direction.S, instructions1));
 
         String expectedOutput = "1 2 N\n3 3 E\n5 5 S\n";
         assertEquals(expectedOutput, mission1.toString());

--- a/src/test/java/com/hhaouari/roverscan/entities/RoverTest.java
+++ b/src/test/java/com/hhaouari/roverscan/entities/RoverTest.java
@@ -1,57 +1,80 @@
 package com.hhaouari.roverscan.entities;
 
 import com.hhaouari.roverscan.entities.enums.Direction;
+import com.hhaouari.roverscan.entities.enums.Instruction;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 class RoverTest {
 
+  private static final Instruction[] instructions1 = new Instruction[]{
+          Instruction.L,
+          Instruction.M,
+          Instruction.L,
+          Instruction.M,
+          Instruction.L,
+          Instruction.M,
+          Instruction.L,
+          Instruction.M,
+          Instruction.M};
+
+  private static final Instruction[] instructions2 = new Instruction[]{
+          Instruction.R,
+          Instruction.M,
+          Instruction.R,
+          Instruction.M,
+          Instruction.R,
+          Instruction.M,
+          Instruction.R,
+          Instruction.M,
+          Instruction.M};
+
   @Test
   void testEquals() {
-    Rover rover1 = new Rover(1, 2, Direction.N, "LMLMLMLMM");
-    Rover rover2 = new Rover(1, 2, Direction.N, "LMLMLMLMM");
+    Rover rover1 = new Rover(1, 2, Direction.N, instructions1);
+    Rover rover2 = new Rover(1, 2, Direction.N, instructions1);
     assertEquals(rover1, rover2);
   }
 
   @Test
   void testEqualsWithDifferentX() {
-    Rover rover1 = new Rover(1, 2, Direction.N, "LMLMLMLMM");
-    Rover rover2 = new Rover(2, 2, Direction.N, "LMLMLMLMM");
+    Rover rover1 = new Rover(1, 2, Direction.N, instructions1);
+    Rover rover2 = new Rover(2, 2, Direction.N, instructions1);
     assertNotEquals(rover1, rover2);
   }
 
   @Test
   void testEqualsWithDifferentY() {
-    Rover rover1 = new Rover(1, 2, Direction.N, "LMLMLMLMM");
-    Rover rover2 = new Rover(1, 3, Direction.N, "LMLMLMLMM");
+    Rover rover1 = new Rover(1, 2, Direction.N, instructions1);
+    Rover rover2 = new Rover(1, 3, Direction.N, instructions1);
     assertNotEquals(rover1, rover2);
   }
 
   @Test
   void testEqualsWithDifferentDirection() {
-    Rover rover1 = new Rover(1, 2, Direction.N, "LMLMLMLMM");
-    Rover rover2 = new Rover(1, 2, Direction.E, "LMLMLMLMM");
+    Rover rover1 = new Rover(1, 2, Direction.N, instructions1);
+    Rover rover2 = new Rover(1, 2, Direction.E, instructions1);
     assertNotEquals(rover1, rover2);
   }
 
   @Test
   void testEqualsWithDifferentInstructions() {
-    Rover rover1 = new Rover(1, 2, Direction.N, "LMLMLMLMM");
-    Rover rover2 = new Rover(1, 2, Direction.N, "LMLMLMLM");
+    Rover rover1 = new Rover(1, 2, Direction.N, instructions1);
+    Rover rover2 = new Rover(1, 2, Direction.N, instructions2);
     assertEquals(rover1, rover2);
   }
 
   @Test
   void testHashCode() {
-    Rover rover1 = new Rover(1, 2, Direction.N, "LMLMLMLMM");
-    Rover rover2 = new Rover(1, 2, Direction.N, "LMLMLMLMM");
+    Rover rover1 = new Rover(1, 2, Direction.N, instructions1);
+    Rover rover2 = new Rover(1, 2, Direction.N, instructions1);
     assertEquals(rover1.hashCode(), rover2.hashCode());
   }
 
   @Test
   void testToString() {
-    Rover rover = new Rover(1, 2, Direction.N, "LMLMLMLMM");
+    Rover rover = new Rover(1, 2, Direction.N, instructions1);
     String expectedOutput = "1 2 N";
     assertEquals(expectedOutput, rover.toString());
   }

--- a/src/test/java/com/hhaouari/roverscan/services/DirectionHelperTest.java
+++ b/src/test/java/com/hhaouari/roverscan/services/DirectionHelperTest.java
@@ -1,6 +1,7 @@
 package com.hhaouari.roverscan.services;
 
 import com.hhaouari.roverscan.entities.enums.Direction;
+import com.hhaouari.roverscan.entities.enums.Instruction;
 import com.hhaouari.roverscan.exceptions.DirectionInvalidInstructionException;
 import com.hhaouari.roverscan.services.impl.DirectionHelperImpl;
 import org.junit.jupiter.api.AfterEach;
@@ -27,56 +28,56 @@ class DirectionHelperTest {
 
     @Test
     void testGetNewDirectionNToL() {
-        Direction direction = directionHelper.getNewDirection(Direction.N, 'L');
+        Direction direction = directionHelper.getNewDirection(Direction.N, Instruction.L);
         assertEquals(Direction.W, direction);
     }
 
     @Test
     void testGetNewDirectionNToR() {
-        Direction direction = directionHelper.getNewDirection(Direction.N, 'R');
+        Direction direction = directionHelper.getNewDirection(Direction.N, Instruction.R);
         assertEquals(Direction.E, direction);
     }
 
     @Test
     void testGetNewDirectionSToL() {
-        Direction direction = directionHelper.getNewDirection(Direction.S, 'L');
+        Direction direction = directionHelper.getNewDirection(Direction.S, Instruction.L);
         assertEquals(Direction.E, direction);
     }
 
     @Test
     void testGetNewDirectionSToR() {
-        Direction direction = directionHelper.getNewDirection(Direction.S, 'R');
+        Direction direction = directionHelper.getNewDirection(Direction.S, Instruction.R);
         assertEquals(Direction.W, direction);
     }
 
     @Test
     void testGetNewDirectionEToL() {
-        Direction direction = directionHelper.getNewDirection(Direction.E, 'L');
+        Direction direction = directionHelper.getNewDirection(Direction.E, Instruction.L);
         assertEquals(Direction.N, direction);
     }
 
     @Test
     void testGetNewDirectionEToR() {
-        Direction direction = directionHelper.getNewDirection(Direction.E, 'R');
+        Direction direction = directionHelper.getNewDirection(Direction.E, Instruction.R);
         assertEquals(Direction.S, direction);
     }
 
     @Test
     void testGetNewDirectionWToL() {
-        Direction direction = directionHelper.getNewDirection(Direction.W, 'L');
+        Direction direction = directionHelper.getNewDirection(Direction.W, Instruction.L);
         assertEquals(Direction.S, direction);
     }
 
     @Test
     void testGetNewDirectionWToR() {
-        Direction direction = directionHelper.getNewDirection(Direction.W, 'R');
+        Direction direction = directionHelper.getNewDirection(Direction.W, Instruction.R);
         assertEquals(Direction.N, direction);
     }
 
     @Test
     void testGetNewDirectionNToMInvalid() {
         assertThrows(DirectionInvalidInstructionException.class, () -> {
-            directionHelper.getNewDirection(Direction.N, 'M');
+            directionHelper.getNewDirection(Direction.N, Instruction.M);
         });
     }
 

--- a/src/test/java/com/hhaouari/roverscan/services/MissionControlServiceTest.java
+++ b/src/test/java/com/hhaouari/roverscan/services/MissionControlServiceTest.java
@@ -5,7 +5,9 @@ import com.hhaouari.roverscan.entities.Mission;
 import com.hhaouari.roverscan.entities.Plateau;
 import com.hhaouari.roverscan.entities.Rover;
 import com.hhaouari.roverscan.entities.enums.Direction;
+import com.hhaouari.roverscan.entities.enums.Instruction;
 import com.hhaouari.roverscan.services.impl.MissionControlServiceImpl;
+import org.apache.logging.log4j.util.IndexedStringMap;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -19,6 +21,42 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 class MissionControlServiceTest {
 
     private MissionControlService missionControlService;
+
+    private static final Instruction[] instructions1 = new Instruction[]{
+            Instruction.L,
+            Instruction.M,
+            Instruction.L,
+            Instruction.M,
+            Instruction.L,
+            Instruction.M,
+            Instruction.L,
+            Instruction.M,
+            Instruction.M};
+
+    //MMRMMRMRRM
+    private static final Instruction[] instructions2 = new Instruction[]{
+            Instruction.M,
+            Instruction.M,
+            Instruction.R,
+            Instruction.M,
+            Instruction.M,
+            Instruction.R,
+            Instruction.M,
+            Instruction.R,
+            Instruction.R,
+            Instruction.M};
+
+    Instruction[] outPlateauInstruction = new Instruction[]{
+            Instruction.M,
+            Instruction.M,
+            Instruction.M,
+            Instruction.M,
+            Instruction.M,
+            Instruction.M,
+            Instruction.M,
+            Instruction.M,
+            Instruction.M};
+
 
     @BeforeEach
     void setUp() {
@@ -36,8 +74,8 @@ class MissionControlServiceTest {
         Mission expectedMission = new Mission();
         expectedMission.setPlateau(new Plateau(5, 5));
         expectedMission.setRovers(Arrays.asList(
-                new Rover(1, 3, Direction.N, null),
-                new Rover(5, 1, Direction.E, null)));
+                new Rover(1, 3, Direction.N, instructions1),
+                new Rover(5, 1, Direction.E, instructions2)));
         assertEquals(expectedMission, mission);
 
     }
@@ -65,14 +103,14 @@ class MissionControlServiceTest {
         Mission mission = new Mission();
         mission.setPlateau(new Plateau(5, 5));
         mission.setRovers(Arrays.asList(
-                new Rover(1, 2, Direction.N, "LMLMLMLMM"),
-                new Rover(3, 3, Direction.E, "MMRMMRMRRM")));
+                new Rover(1, 2, Direction.N, instructions1),
+                new Rover(3, 3, Direction.E, instructions2)));
         missionControlService.runMissionRoversInstructions(mission);
         Mission expectedMission = new Mission();
         expectedMission.setPlateau(new Plateau(5, 5));
         expectedMission.setRovers(Arrays.asList(
-                new Rover(1, 3, Direction.N, null),
-                new Rover(5, 1, Direction.E, null)));
+                new Rover(1, 3, Direction.N, instructions1),
+                new Rover(5, 1, Direction.E, instructions2)));
         assertEquals(expectedMission, mission);
     }
 
@@ -80,7 +118,7 @@ class MissionControlServiceTest {
     void testRunMissionRoversInstructionsOffPlateauLimit() {
         Mission mission = new Mission();
         mission.setPlateau(new Plateau(5, 5));
-        String outPlateauInstruction = "MMMMMMMMMMMMMMMMMM";
+
         mission.setRovers(Arrays.asList(
                 new Rover(1, 1, Direction.N, outPlateauInstruction),
                 new Rover(1, 1, Direction.E, outPlateauInstruction),
@@ -91,10 +129,11 @@ class MissionControlServiceTest {
         Mission expectedMission = new Mission();
         expectedMission.setPlateau(new Plateau(5, 5));
         expectedMission.setRovers(Arrays.asList(
-                new Rover(1, 5, Direction.N, null),
-                new Rover(5, 1, Direction.E, null),
-                new Rover(1, 0, Direction.S, null),
-                new Rover(0, 1, Direction.W, null)));
+                new Rover(1, 5, Direction.N, outPlateauInstruction),
+                new Rover(5, 1, Direction.E, outPlateauInstruction),
+                new Rover(1, 0, Direction.S, outPlateauInstruction),
+                new Rover(0, 1, Direction.W, outPlateauInstruction)));
+
         assertEquals(expectedMission, mission);
 
     }

--- a/src/test/java/com/hhaouari/roverscan/services/PositionHelperTest.java
+++ b/src/test/java/com/hhaouari/roverscan/services/PositionHelperTest.java
@@ -3,6 +3,7 @@ package com.hhaouari.roverscan.services;
 import com.hhaouari.roverscan.entities.Plateau;
 import com.hhaouari.roverscan.entities.Rover;
 import com.hhaouari.roverscan.entities.enums.Direction;
+import com.hhaouari.roverscan.entities.enums.Instruction;
 import com.hhaouari.roverscan.services.impl.PositionHelperImpl;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -13,6 +14,17 @@ import static org.junit.jupiter.api.Assertions.*;
 class PositionHelperTest {
 
     PositionHelper positionHelper;
+
+    private static final Instruction[] instructions1 = new Instruction[]{
+            Instruction.L,
+            Instruction.M,
+            Instruction.L,
+            Instruction.M,
+            Instruction.L,
+            Instruction.M,
+            Instruction.L,
+            Instruction.M,
+            Instruction.M};
 
     @BeforeEach
     void setUp() {
@@ -26,53 +38,53 @@ class PositionHelperTest {
 
     @Test
     void moveForwardWest() {
-        Rover rover = new Rover(1, 2, Direction.W, "LMLMLMLMM");
+        Rover rover = new Rover(1, 2, Direction.W, instructions1);
         positionHelper.moveForwardWest(rover);
         assertEquals(0, rover.getX());
     }
 
     @Test
     void moveForwardEast() {
-        Rover rover = new Rover(1, 2, Direction.E, "LMLMLMLMM");
+        Rover rover = new Rover(1, 2, Direction.E, instructions1);
         positionHelper.moveForwardEast(rover, new Plateau(5, 5));
         assertEquals(2, rover.getX());
     }
 
     @Test
     void moveForwardSouth() {
-        Rover rover = new Rover(1, 2, Direction.S, "LMLMLMLMM");
+        Rover rover = new Rover(1, 2, Direction.S, instructions1);
         positionHelper.moveForwardSouth(rover);
         assertEquals(1, rover.getY());
     }
 
     @Test
     void moveForwardNorth() {
-        Rover rover = new Rover(1, 2, Direction.N, "LMLMLMLMM");
+        Rover rover = new Rover(1, 2, Direction.N, instructions1);
         positionHelper.moveForwardNorth(rover, new Plateau(5, 5));
         assertEquals(3, rover.getY());
     }
 
     @Test
     void moveForwardWestWithInvalidPosition() {
-        Rover rover = new Rover(0, 2, Direction.W, "LMLMLMLMM");
+        Rover rover = new Rover(0, 2, Direction.W, instructions1);
         assertFalse(positionHelper.moveForwardWest(rover));
     }
 
     @Test
     void moveForwardSouthWithInvalidPosition() {
-        Rover rover = new Rover(1, 0, Direction.S, "LMLMLMLMM");
+        Rover rover = new Rover(1, 0, Direction.S, instructions1);
         assertFalse(positionHelper.moveForwardSouth(rover));
     }
 
     @Test
     void moveForwardEastWithInvalidPosition() {
-        Rover rover = new Rover(5, 2, Direction.E, "LMLMLMLMM");
+        Rover rover = new Rover(5, 2, Direction.E, instructions1);
         assertFalse(positionHelper.moveForwardEast(rover, new Plateau(5, 5)));
     }
 
     @Test
     void moveForwardNorthWithInvalidPosition() {
-        Rover rover = new Rover(1, 5, Direction.N, "LMLMLMLMM");
+        Rover rover = new Rover(1, 5, Direction.N, instructions1);
         assertFalse(positionHelper.moveForwardNorth(rover, new Plateau(5, 5)));
     }
 }

--- a/src/test/java/com/hhaouari/roverscan/services/RoverControlServiceTest.java
+++ b/src/test/java/com/hhaouari/roverscan/services/RoverControlServiceTest.java
@@ -3,6 +3,7 @@ package com.hhaouari.roverscan.services;
 import com.hhaouari.roverscan.entities.Plateau;
 import com.hhaouari.roverscan.entities.Rover;
 import com.hhaouari.roverscan.entities.enums.Direction;
+import com.hhaouari.roverscan.entities.enums.Instruction;
 import com.hhaouari.roverscan.services.impl.RoverControlServiceImpl;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -14,6 +15,30 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 @SpringBootTest
 class RoverControlServiceTest {
     RoverControlService roverControlService;
+
+    private static final Instruction[] instructions1 = new Instruction[]{
+            Instruction.L,
+            Instruction.M,
+            Instruction.L,
+            Instruction.M,
+            Instruction.L,
+            Instruction.M,
+            Instruction.L,
+            Instruction.M,
+            Instruction.M};
+
+    private static final Instruction[] instructions2 = new Instruction[]{
+            Instruction.M,
+            Instruction.M,
+            Instruction.R,
+            Instruction.M,
+            Instruction.M,
+            Instruction.R,
+            Instruction.M,
+            Instruction.R,
+            Instruction.R,
+            Instruction.M};
+
 
     @BeforeEach
     void setUp() {
@@ -50,7 +75,7 @@ class RoverControlServiceTest {
         Rover rover = new Rover(1, 2, Direction.N, instruction);
         Plateau plateau = new Plateau(5, 5);
         roverControlService.move(rover, plateau);
-        Rover expectedRover = new Rover(1, 3, Direction.N, null);
+        Rover expectedRover = new Rover(1, 3, Direction.N, instruction);
         assertEquals(expectedRover, rover);
     }
 
@@ -66,47 +91,47 @@ class RoverControlServiceTest {
 
     @Test
     void testTurnLeft() {
-        Rover rover = new Rover(1, 2, Direction.N, "LMLMLMLMM");
+        Rover rover = new Rover(1, 2, Direction.N, instructions1);
         roverControlService.turnLeft(rover);
-        Rover expectedRover = new Rover(1, 2, Direction.W, "LMLMLMLMM");
+        Rover expectedRover = new Rover(1, 2, Direction.W, instructions1);
         assertEquals(expectedRover, rover);
 
     }
 
     @Test
     void testTurnRight() {
-        Rover rover = new Rover(1, 2, Direction.N, "LMLMLMLMM");
+        Rover rover = new Rover(1, 2, Direction.N, instructions1);
         roverControlService.turnRight(rover);
-        Rover expectedRover = new Rover(1, 2, Direction.E, "LMLMLMLMM");
+        Rover expectedRover = new Rover(1, 2, Direction.E, instructions1);
         assertEquals(expectedRover, rover);
 
     }
 
     @Test
     void testMoveForward() {
-        Rover rover = new Rover(1, 2, Direction.N, "LMLMLMLMM");
+        Rover rover = new Rover(1, 2, Direction.N, instructions1);
         Plateau plateau = new Plateau(5, 5);
         roverControlService.moveForward(rover, plateau);
-        Rover expectedRover = new Rover(1, 3, Direction.N, "LMLMLMLMM");
+        Rover expectedRover = new Rover(1, 3, Direction.N, instructions1);
         assertEquals(expectedRover, rover);
     }
 
     @Test
     void testMove() {
-        Rover rover = new Rover(1, 2, Direction.N, "LMLMLMLMM");
+        Rover rover = new Rover(1, 2, Direction.N, instructions1);
         Plateau plateau = new Plateau(5, 5);
         roverControlService.move(rover, plateau);
-        Rover expectedRover = new Rover(1, 3, Direction.N, null);
+        Rover expectedRover = new Rover(1, 3, Direction.N, instructions1);
         assertEquals(rover, expectedRover);
 
     }
 
     @Test
     void testMove2() {
-        Rover rover = new Rover(3, 3, Direction.E, "MMRMMRMRRM");
+        Rover rover = new Rover(3, 3, Direction.E, instructions2);
         Plateau plateau = new Plateau(5, 5);
         roverControlService.move(rover, plateau);
-        Rover expectedRover = new Rover(5, 1, Direction.E, null);
+        Rover expectedRover = new Rover(5, 1, Direction.E, instructions2);
         assertEquals(rover, expectedRover);
     }
 

--- a/src/test/java/com/hhaouari/roverscan/utils/CoordinateStringReaderTest.java
+++ b/src/test/java/com/hhaouari/roverscan/utils/CoordinateStringReaderTest.java
@@ -3,6 +3,7 @@ package com.hhaouari.roverscan.utils;
 import com.hhaouari.roverscan.entities.Plateau;
 import com.hhaouari.roverscan.entities.Rover;
 import com.hhaouari.roverscan.entities.enums.Direction;
+import com.hhaouari.roverscan.entities.enums.Instruction;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -12,6 +13,17 @@ import static org.junit.jupiter.api.Assertions.*;
 class CoordinateStringReaderTest {
 
   private CoordinateStringReader coordinateFileReader;
+
+  private static final Instruction[] instructions1 = new Instruction[]{
+          Instruction.L,
+          Instruction.M,
+          Instruction.L,
+          Instruction.M,
+          Instruction.L,
+          Instruction.M,
+          Instruction.L,
+          Instruction.M,
+          Instruction.M};
 
   @BeforeEach
   void setUp() {
@@ -41,7 +53,7 @@ class CoordinateStringReaderTest {
   @Test
   void readRoverCoordinate() {
     Rover rover = coordinateFileReader.readRoverCoordinate("1 2 N", "LMLMLMLMM");
-    Rover expectedRover = new Rover(1, 2, Direction.N, "LMLMLMLMM");
+    Rover expectedRover = new Rover(1, 2, Direction.N, instructions1);
     assertEquals(expectedRover, rover);
   }
 }

--- a/src/test/java/com/hhaouari/roverscan/utils/MissionFileReaderTest.java
+++ b/src/test/java/com/hhaouari/roverscan/utils/MissionFileReaderTest.java
@@ -5,6 +5,7 @@ import com.hhaouari.roverscan.entities.Mission;
 import com.hhaouari.roverscan.entities.Plateau;
 import com.hhaouari.roverscan.entities.Rover;
 import com.hhaouari.roverscan.entities.enums.Direction;
+import com.hhaouari.roverscan.entities.enums.Instruction;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -19,6 +20,29 @@ class MissionFileReaderTest {
 
     private CoordinateStringReader coordinateFileReader;
     private MissionFileReader missionFileReader;
+
+    private static final Instruction[] instructions1 = new Instruction[]{
+            Instruction.L,
+            Instruction.M,
+            Instruction.L,
+            Instruction.M,
+            Instruction.L,
+            Instruction.M,
+            Instruction.L,
+            Instruction.M,
+            Instruction.M};
+
+    private static final Instruction[] instructions2 = new Instruction[]{
+            Instruction.M,
+            Instruction.M,
+            Instruction.R,
+            Instruction.M,
+            Instruction.M,
+            Instruction.R,
+            Instruction.M,
+            Instruction.R,
+            Instruction.R,
+            Instruction.M};
 
     @BeforeEach
     void setUp() {
@@ -43,7 +67,7 @@ class MissionFileReaderTest {
     @Test
     void testReadingRoverCoordinate() {
         Rover rover = coordinateFileReader.readRoverCoordinate("1 2 N", "LMLMLMLMM");
-        Rover expectedRover = new Rover(1, 2, Direction.N, "LMLMLMLMM");
+        Rover expectedRover = new Rover(1, 2, Direction.N, instructions1);
         assertEquals(expectedRover, rover);
     }
 
@@ -54,8 +78,8 @@ class MissionFileReaderTest {
         Mission expectedMission = new Mission();
         expectedMission.setPlateau(new Plateau(5, 5));
         expectedMission.setRovers(Arrays.asList(
-                new Rover(1, 2, Direction.N, "LMLMLMLMM"),
-                new Rover(3, 3, Direction.E, "MMRMMRMRRM")));
+                new Rover(1, 2, Direction.N, instructions1),
+                new Rover(3, 3, Direction.E, instructions2)));
 
         assertEquals(expectedMission, mission);
     }


### PR DESCRIPTION
    - Add Instruction enum
    - Update Rover class to use Instruction enum
    - Update RoverControlService to use Instruction enum
    - Update DirectionHelper to use Instruction enum
    - Update DirectionHelperImpl to use Instruction enum
    - Update MissionTest to use Instruction enum
    - Update RoverTest to use Instruction enum
    - Update DirectionHelperTest to use Instruction enum
    - Update MissionControlServiceTest to use Instruction enum
    - Update PositionHelperTest to use Instruction enum
    - Update RoverControlServiceTest to use Instruction enum
    - Update CoordinateStringReaderTest to use Instruction enum
    - Update MissionFileReaderTest to use Instruction enum
    - Keep compatibility with old String instructions and char instructions